### PR TITLE
Replaced deprecated .live() function with .on().

### DIFF
--- a/wpfp.js
+++ b/wpfp.js
@@ -1,5 +1,5 @@
 jQuery(document).ready( function($) {
-    $('.wpfp-link').live('click', function() {
+    $('.wpfp-span').on('click', '.wpfp-link', function() {
         dhis = $(this);
         wpfp_do_js( dhis, 1 );
         // for favorite post listing page


### PR DESCRIPTION
![screen shot 2016-04-06 at 10 39 14 pm](https://cloud.githubusercontent.com/assets/1135407/14332193/a4e19e86-fc48-11e5-8baf-123ebe017ddf.png)
