### PR TITLE
Fix convert var string to var array

### DIFF
--- a/wp-favorite-posts.php
+++ b/wp-favorite-posts.php
@@ -124,6 +124,7 @@ function wpfp_die_or_go($str) {
 
 function wpfp_add_to_usermeta($post_id) {
     $wpfp_favorites = wpfp_get_user_meta();
+    if(empty($wpfp_favorites) or !is_array($wpfp_favorites)) $wpfp_favorites = array();
     $wpfp_favorites[] = $post_id;
     wpfp_update_user_meta($wpfp_favorites);
     return true;


### PR DESCRIPTION
PHP Fatal error:  Uncaught Error: [] operator not supported for strings in /home/admin/web/public_html/wp-content/plugins/wp-favorite-posts/wp-favorite-posts.php:127